### PR TITLE
:BUGFIX: generating gmarkers array for MarkerManager

### DIFF
--- a/code/GoogleMapAPI.php
+++ b/code/GoogleMapAPI.php
@@ -584,7 +584,7 @@ class GoogleMapAPI extends ViewableData
         // JS variable init
         $this->content .= "\t".'<script type="text/javascript">'."\n";
         $this->content .= "\t".'var map;'."\n";
-        $this->content .= "\t".'var gmarkers = [""];'."\n";
+        $this->content .= "\t".'var gmarkers = [];'."\n";
         $this->content .= "\t".'var gicons = [];'."\n";
         $this->content .= "\t".'var clusterer = null;'."\n";
         $this->content .= "\t".'var current_lat = 0;'."\n";

--- a/code/GoogleMapAPI.php
+++ b/code/GoogleMapAPI.php
@@ -468,7 +468,7 @@ class GoogleMapAPI extends ViewableData
      */
     public function addMarkerAsObject(ViewableData $obj) {    
     	if($obj instanceof Mappable) {
-        	if(($obj->getLatitude() > 0) || ($obj->getLongitude() > 0)) {
+        	if($obj->getLatitude() || $obj->getLongitude()) { {
         		$cat = $obj->hasMethod('getMapCategory') ? $obj->getMapCategory() : "default";
 		        $this->addMarkerByCoords($obj->getLatitude(), $obj->getLongitude(), $obj->getMapContent(), $cat, $obj->getMapPin());
 	        }


### PR DESCRIPTION
:BUGFIX: Removed empty quotes, to prevent error when using MarkerManager
->Empty quotes generate an empty element in array which MarkerManager can´t handle 
(Error: Method marker.getLatLng() does not exist)
